### PR TITLE
Fixed paths to support Windows OS using MINGW64

### DIFF
--- a/memeocr.py
+++ b/memeocr.py
@@ -6,8 +6,8 @@ import cv2
 class MemeOCR:
     def __init__(self):
         self._white_thresh = 240
-        self._tmp_image_fname = '/tmp/memeocr.jpg'
-        self._tmp_txt_base = '/tmp/memeocr'
+        self._tmp_image_fname = './memeocr.jpg'
+        self._tmp_txt_base = './memeocr'
         self._tmp_txt_fname = self._tmp_txt_base + '.txt'
         self._template_image = None
         self._keep_tmp_files = False
@@ -45,7 +45,7 @@ class MemeOCR:
         cv2.imwrite(self._tmp_image_fname, img)
 
     def _exec_tesseract(self):
-        cmd = 'env TESSDATA_PREFIX=./tessdata tesseract -l joh %s %s > /dev/null' % (self._tmp_image_fname, self._tmp_txt_base)
+        cmd = 'env TESSDATA_PREFIX=./tessdata tesseract -l joh %s %s' % (self._tmp_image_fname, self._tmp_txt_base)
         os.system(cmd)
 
     def _read_txt(self):


### PR DESCRIPTION
Windows OS were not supported, even using MINGW64 due to the reference to UNIX-specific paths.

We could instead just use the current directory as working directory. I have not yet found a way to properly replace the >dev/null instruction to get rid of the output but due how the script work I think it would be actually better if output is shown